### PR TITLE
Fix schema.rb file for good

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 2018_05_21_163014) do
     t.datetime "last_sign_in_at"
     t.inet "current_sign_in_ip"
     t.inet "last_sign_in_ip"
-    t.string "name"
+    t.string "name", default: "", null: false
     t.text "about"
     t.string "avatar"
     t.datetime "created_at", null: false


### PR DESCRIPTION
So… `db/schema.rb` file should now display `t.string "name", default: "", null: false`, always. No exception. 

Please, do a `rails db:drop db:create db:migrate` on your feature branch after your `git pull origin master` to clean the database once and for all. 🤞 