### PR TITLE
Add address autocompletion using Google Maps Places API

### DIFF
--- a/app/javascript/components/autocomplete.js
+++ b/app/javascript/components/autocomplete.js
@@ -1,0 +1,16 @@
+function autocomplete() {
+  document.addEventListener("DOMContentLoaded", function() {
+    var hideoutAddress = document.getElementById('hideout_address');
+
+    if (hideoutAddress) {
+      var autocomplete = new google.maps.places.Autocomplete(hideoutAddress, { types: [ 'geocode' ] });
+      google.maps.event.addDomListener(hideoutAddress, 'keydown', function(e) {
+        if (e.key === "Enter") {
+          e.preventDefault(); // Do not submit the form on Enter.
+        }
+      });
+    }
+  });
+}
+
+export { autocomplete };

--- a/app/javascript/packs/map.js
+++ b/app/javascript/packs/map.js
@@ -1,4 +1,5 @@
 import GMaps from 'gmaps/gmaps.js';
+import { autocomplete } from '../components/autocomplete';
 
 const mapElement = document.getElementById('map');
 if (mapElement) { // don't try to build a map if there's no div#map to inject in
@@ -14,3 +15,5 @@ if (mapElement) { // don't try to build a map if there's no div#map to inject in
     map.fitLatLngBounds(markers);
   }
 }
+
+autocomplete();

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
       <%= yield %>
       <%= javascript_include_tag 'application' %>
       <%= javascript_pack_tag 'application' %>
-      <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js" %>
+      <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places&key=#{ENV['GOOGLE_API_BROWSER_KEY']}" %>
       <%= javascript_pack_tag "map" %>
     </main>
   </body>


### PR DESCRIPTION
This PR adds autocompletion on the address field of the Hideouts#create view.

![kapture-autocompletion](https://user-images.githubusercontent.com/3286488/40419183-cccb5270-5e84-11e8-911b-99edf61b6525.gif)
