### PR TITLE
Turn images into links on Hideouts grid

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -2,10 +2,12 @@
   position: relative !important;
   height: 100% !important;
   margin: 15px 10px;
-  // display: flex;
   display: inline-block !important;
   vertical-align: top !important;
-  // justify-content: space-around;
+  a:hover,
+  a:focus {
+  text-decoration: none !important;
+  }
 }
 
 .card-image {
@@ -22,23 +24,17 @@
 
 .card-description {
   margin-top: 10px;
-  h2, p {
+  h2,
+  p,
+  a {
     margin: 0 !important;
     color: #222222;
-  }
-  a {
-  color: #222222;
-  }
-  a:hover {
-    text-decoration: none;
-    color: #D22F2B;
   }
 }
 
 .card-name {
   h2 {
   font-size: 14px;
-  color: #222222;
   }
 }
 

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -23,3 +23,7 @@
 .filters {
   margin-left: 30px;
 }
+
+.hidden {
+  display: none;
+}

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -17,7 +17,7 @@
   height: 100vh;
   position: sticky !important;
   top: 0 !important;
-  overflow: hidden;
+  // overflow: hidden;
 }
 
 .filters {

--- a/app/views/hideouts/index.html.erb
+++ b/app/views/hideouts/index.html.erb
@@ -29,38 +29,46 @@
       <div class="row">
         <% @hideouts.each do |hideout| %>
           <div class="col-xs-12 col-sm-6 col-md-4">
-            <% if hideout.photo.blank? %>
+            <% if hideout.blank? %>
+
+              <div class="hidden"><%= hideout.name %></div>
+
+            <% elsif hideout.photo.blank? %>
 
               <div class="card">
-                <%= image_tag('banner.jpg', height: 190, width: 290, crop: :fill, class: 'card-image') %>
-                <div class="card-description">
-                  <div class="card-name">
-                    <h2><%= link_to hideout.name, hideout_path(hideout)%>
+                <%= link_to image_tag('banner.jpg', height: 190, width: 290, crop: :fill, class: 'card-image'), hideout_path(hideout) %>
+                <%= link_to hideout_path(hideout) do %>
+                  <div class="card-description">
+                    <div class="card-name">
+                      <h2><%= hideout.name %>
+                    </div>
+                    <div class="card-price">
+                      <p><%= hideout.price %> <%= " €" %> </p>
+                    </div>
+                    <div class="card-safety">
+                      <p><%= hideout.safety %> <%= " safety" %></p>
+                    </div>
                   </div>
-                  <div class="card-price">
-                    <p><%= hideout.price %> <%= " €" %> </p>
-                  </div>
-                  <div class="card-safety">
-                    <p><%= hideout.safety %> <%= " safety" %></p>
-                  </div>
-                </div>
+                <% end %>
               </div>
 
             <% else %>
 
               <div class="card">
-                <%= cl_image_tag hideout.photo, height: 190, width: 290, crop: :fill, class: 'card-image' %>
-                <div class="card-description">
-                  <div class="card-name">
-                    <h2><%= link_to hideout.name, hideout_path(hideout)%></h2>
+                <%= link_to cl_image_tag(hideout.photo, height: 190, width: 290, crop: :fill, class: 'card-image'), hideout_path(hideout) %>
+                <%= link_to hideout_path(hideout) do %>
+                  <div class="card-description">
+                    <div class="card-name">
+                      <h2><%= hideout.name %></h2>
+                    </div>
+                    <div class="card-price">
+                      <p><%= hideout.price %> <%= " €" %></p>
+                    </div>
+                    <div class="card-safety">
+                      <p><%= hideout.safety %> <%= " safety" %></p>
+                    </div>
                   </div>
-                  <div class="card-price">
-                    <p><%= hideout.price %> <%= " €" %></p>
-                  </div>
-                  <div class="card-safety">
-                    <p><%= hideout.safety %> <%= " safety" %></p>
-                  </div>
-                </div>
+                <% end %>
               </div>
 
             <% end %>

--- a/app/views/hideouts/index.html.erb
+++ b/app/views/hideouts/index.html.erb
@@ -71,6 +71,6 @@
       </div>
     </section>
 
-    <aside id="map" style="width: 100%; height: 600px;" data-markers="<%= @markers.to_json %>"></aside>
+    <aside id="map" data-markers="<%= @markers.to_json %>"></aside>
 
   </div>


### PR DESCRIPTION
This PR turns images into links to `Hideout#show` on the `Hideout#indew` view. Also, the whole `card-description` **div** is now a link, which means that a user can click the zone below the image and _still_ get to the hideout#show view although he or she didn't clicked on text. Closes #82.

![kapture-image-as-link](https://user-images.githubusercontent.com/3286488/40538577-68645798-6012-11e8-9595-6b591c23b239.gif)
